### PR TITLE
Updated usage of add_options_page and load_plugin_textdomain

### DIFF
--- a/user-photo.php
+++ b/user-photo.php
@@ -74,7 +74,7 @@ $userphoto_prevent_override_avatar = false;
 
 # Load up the localization file if we're using WordPress in a different language
 # Place it in the "localization" folder and name it "user-photo-[value in wp-config].mo"
-load_plugin_textdomain('user-photo', PLUGINDIR . '/user-photo/localization'); #(thanks Pakus)
+load_plugin_textdomain('user-photo', false, dirname( plugin_basename( __FILE__ ) ) . '/localization/'); #(thanks Pakus)
 
 function userphoto__init(){
 	if(get_option('userphoto_override_avatar') && !is_admin())
@@ -678,7 +678,7 @@ add_action('edit_user_profile', 'userphoto_display_selector_fieldset');
 
 function userphoto_add_page() {
 	//if (function_exists('add_options_page'))
-	add_options_page('User Photo', 'User Photo', 8, __FILE__, 'userphoto_options_page');
+	add_options_page('User Photo', 'User Photo', 'add_users', __FILE__, 'userphoto_options_page');
 }
 add_action('admin_menu', 'userphoto_add_page');
 


### PR DESCRIPTION
add_options_page and load_plugin_textdomain were causing notices (in WP 3.4.1) due to depreciated arguments. More details at: http://wordpress.org/support/topic/plugin-user-photo-current-version-causing-notices-warnings-fixed?replies=1#post-2971490
