### PR TITLE
Added option for white background instead of black

### DIFF
--- a/src/user-photo.php
+++ b/src/user-photo.php
@@ -825,6 +825,13 @@ function userphoto_options_page()
                name="userphoto_jpeg_compression" value="<?php echo $userphoto_jpeg_compression ?>"/>%
         <?php echo $afterRow ?>
         <?php echo $beforeRow ?>
+        <label for="userphoto_white_transparency">
+            <?php _e('Fill transparency with white instead of black') ?>
+        </label>
+        <?php echo $betweenRow; ?>
+        <input type="checkbox" name="userphoto_white_transparency" id="userphoto_white_transparency" value="1" />
+        <?php echo $afterRow; ?>
+        <?php echo $beforeRow ?>
         <label for="userphoto_admin_notified">
             <?php _e("Notify this administrator by email when user photo needs approval: ", 'user-photo') ?>
         </label>
@@ -922,6 +929,12 @@ function userphoto_resize_image($filename, $newFilename, $cropDetails, &$error) 
         $full_dimension = get_option('userphoto_maximum_dimension');
 
         $imageresized = imagecreatetruecolor($cropDetails['tgtW'], $cropDetails['tgtH']);
+
+        if ( get_option( 'userphoto_white_transparency', false ) ) {
+            $backgroundColor = imagecolorallocate($imageresized, 255, 255, 255);
+            imagefill($imageresized, 0, 0, $backgroundColor);
+        }
+
         @ imagecopyresampled($imageresized, $image,
                              0, 0, $cropDetails['x'], $cropDetails['y'],
                              $cropDetails['tgtW'], $cropDetails['tgtH'], $cropDetails['w'], $cropDetails['h']);

--- a/src/user-photo.php
+++ b/src/user-photo.php
@@ -826,10 +826,11 @@ function userphoto_options_page()
         <?php echo $afterRow ?>
         <?php echo $beforeRow ?>
         <label for="userphoto_white_transparency">
-            <?php _e('Fill transparency with white instead of black') ?>
+            <?php _e('Fill with white instead of black', 'user-photo') ?>
         </label>
         <?php echo $betweenRow; ?>
         <input type="checkbox" name="userphoto_white_transparency" id="userphoto_white_transparency" value="1" />
+        <?php _e("Change the color which replaces transparency during resize from black to white.", 'user-photo') ?>
         <?php echo $afterRow; ?>
         <?php echo $beforeRow ?>
         <label for="userphoto_admin_notified">

--- a/src/user-photo.php
+++ b/src/user-photo.php
@@ -732,6 +732,7 @@ function userphoto_options_page()
     $userphoto_level_moderated = get_option('userphoto_level_moderated');
     $userphoto_use_avatar_fallback = get_option('userphoto_use_avatar_fallback');
     $userphoto_override_avatar = get_option('userphoto_override_avatar');
+    $userphoto_white_transparency = get_option('userphoto_white_transparency');
 
     #Get new updated option values, and save them
     if (@$_POST['action'] == 'update') {
@@ -757,6 +758,9 @@ function userphoto_options_page()
 
         $userphoto_override_avatar = !empty($_POST['userphoto_override_avatar']);
         update_option('userphoto_override_avatar', $userphoto_override_avatar);
+
+        $userphoto_white_transparency = !empty($_POST['userphoto_white_transparency']);
+        update_option('userphoto_white_transparency', $userphoto_white_transparency);
 
         ?>
     <div id="message" class="updated fade"><p><strong><?php _e('Options saved.'); ?></strong></p></div>
@@ -829,7 +833,8 @@ function userphoto_options_page()
             <?php _e('Fill with white instead of black', 'user-photo') ?>
         </label>
         <?php echo $betweenRow; ?>
-        <input type="checkbox" name="userphoto_white_transparency" id="userphoto_white_transparency" value="1" />
+        <input type="checkbox" name="userphoto_white_transparency" id="userphoto_white_transparency" 
+                <?php if ($userphoto_override_avatar) echo ' checked="checked"'; ?> value="1" />
         <?php _e("Change the color which replaces transparency during resize from black to white.", 'user-photo') ?>
         <?php echo $afterRow; ?>
         <?php echo $beforeRow ?>

--- a/src/user-photo.php
+++ b/src/user-photo.php
@@ -834,7 +834,7 @@ function userphoto_options_page()
         </label>
         <?php echo $betweenRow; ?>
         <input type="checkbox" name="userphoto_white_transparency" id="userphoto_white_transparency" 
-                <?php if ($userphoto_override_avatar) echo ' checked="checked"'; ?> value="1" />
+                <?php if ($userphoto_white_transparency) echo ' checked="checked"'; ?> value="1" />
         <?php _e("Change the color which replaces transparency during resize from black to white.", 'user-photo') ?>
         <?php echo $afterRow; ?>
         <?php echo $beforeRow ?>


### PR DESCRIPTION
Currently, user-photo uses a black image to place the resized image onto.  When an image has transparency, it shows as black in the resulting image.

This provides an option to make the fill be white instead of black.
